### PR TITLE
Removed empty FAQ page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,8 +25,6 @@ website:
     center:
       - text: "About"
         href: about.qmd
-      - text: "FAQ"
-        href: docs/faq/introduction.qmd
       - text: "License"
         href: license.qmd
     right:


### PR DESCRIPTION
If this becomes useful in the future, we can add it back.

Closes #5 