### PR TITLE
Add contribute guide to rendered site

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,10 +1,10 @@
 # Contribution Guidelines
 
-There are quite a few ways you could get involved with the Contributor Experience project. You can:
+There are quite a few ways to get involved with the Contributor Experience project. You can:
 
 - join one of our [community calls](docs/about/calendar.qmd);
 - join our [Zulip chat](https://contributor-experience.zulipchat.com/join/r3bbxavdymqbyjiu32mtqyqi/)
-- share your ideas by [filing issues](https://github.com/contributor-experience/handbook/issues/new), submitting [Pull Requests](https://docs.github.com/en/pull-requests) or commenting on existing discussions;
+- share your ideas by [filing issues](https://github.com/contributor-experience/handbook/issues/new), submitting [Pull Requests](https://docs.github.com/en/pull-requests), or commenting on existing discussions;
 - address issues filed by other contributors;
 - review submitted PRs.
 
@@ -12,7 +12,7 @@ There are quite a few ways you could get involved with the Contributor Experienc
 
 Never made an open source contribution before? Wondering how contributions work in our project? Here's a quick rundown!
 
-1. Find an issue that you are interested in addressing or a content page or feature that you would like to add.
+1. Find an issue that you are interested in addressing or decide on content or feature that you would like to add.
 
 2. Fork the [Contributor Experience Handbook repository](https://github.com/contributor-experience/handbook) to your GitHub profile. This means that you will have a copy of the repository `<github-username>/handbook.`
 
@@ -24,7 +24,7 @@ Never made an open source contribution before? Wondering how contributions work 
    git clone https://github.com/<github-username>/handbook.git.
    ```
 
-   This means you will now have a local copy of all the contents in the GitHub repository in your computer, under the `handbook` folder. You can rename this folder to any names you like - all the git-related information will be unchanged.
+   This means you will now have a local copy of all the contents in the GitHub repository on your computer, in the `handbook` folder. You can rename this folder to any names you like - all the git-related information will be unchanged.
 
 4. Add the `upstream` remote
 
@@ -59,7 +59,7 @@ Never made an open source contribution before? Wondering how contributions work 
    git pull upstream main
    ```
 
-6. Create a new branch and switch to it for your issue fix or content page using:
+6. Create a new branch and switch to it to work on your task (a selected issue, content, or feature):
 
    ```
    git switch -c <branch-name>
@@ -67,11 +67,9 @@ Never made an open source contribution before? Wondering how contributions work 
 
    It is good practice to create a new branch for each new fix/improvement your are working on. This ensures the history of the changes to the project is more organized. You can name your branch anything - this does not interfere with the commit history.
 
-7. Make the appropriate changes for the issue you are trying to address or the feature that you want to add
 
-   This is when you write, fix existing content or otherwise do your magic ✨
 
-8. Add the changes to the staging area and commit them to the branch you are working on
+7. Once you finished making changes to the existing code, you need to add all these changes to the staging area and commit them to the branch you are working on
 
    ```
    git add <files-to-be-changed>
@@ -90,7 +88,7 @@ Never made an open source contribution before? Wondering how contributions work 
 
 11. Title the **pull request** with a short description of the changes made
 
-12. Wait for the pull request to be reviewed by a maintainer
+12. Wait for the pull request to be reviewed by the project team member
 
 13. Make changes to the pull request if the reviewing maintainer recommends them
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -90,7 +90,7 @@ Never made an open source contribution before? Wondering how contributions work 
 
 12. Wait for the pull request to be reviewed by the project team member
 
-13. Make changes to the pull request if the reviewing maintainer recommends them
+13. Make changes to the pull request if the reviewing team member recommends them
 
 14. Celebrate your success after your pull request is merged!
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -90,6 +90,12 @@ Never made an open source contribution before? Wondering how contributions work 
 
 12. Wait for the pull request to be reviewed by the project team member
 
+   Currently, the Contributor Experience project is led by a
+   [team of three people](docs/about/team.qmd). While only these team members
+   have GitHub permissions to merge Pull Requests, we welcome Pull Request
+   reviews by anyone - suggestions and comments are valuable contributions to
+   our project.
+
 13. Make changes to the pull request if the reviewing team member recommends them
 
 14. Celebrate your success after your pull request is merged!

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,12 +1,12 @@
 # Contribution Guidelines
 
-There are quite a few ways to get involved with the Contributor Experience project. You can:
+There are quite a few ways to get involved with the Contributor Experience Project. You can:
 
-- join one of our [community calls](docs/about/calendar.qmd);
+- join one of our [community calls](docs/about/calendar.qmd)
 - join our [Zulip chat](https://contributor-experience.zulipchat.com/join/r3bbxavdymqbyjiu32mtqyqi/)
-- share your ideas by [filing issues](https://github.com/contributor-experience/handbook/issues/new), submitting [Pull Requests](https://docs.github.com/en/pull-requests), or commenting on existing discussions;
-- address issues filed by other contributors;
-- review submitted PRs.
+- share your ideas by [filing issues](https://github.com/contributor-experience/handbook/issues/new), submitting [pull requests](https://docs.github.com/en/pull-requests), or commenting on existing discussions
+- address issues filed by other contributors
+- review submitted PRs
 
 ## How do I make a contribution to the Handbook?
 
@@ -21,16 +21,16 @@ Never made an open source contribution before? Wondering how contributions work 
 3. Clone the repository to your local machine using:
 
    ```
-   git clone https://github.com/<github-username>/handbook.git.
+   git clone https://github.com/<github-username>/handbook.git
    ```
 
-   This means you will now have a local copy of all the contents in the GitHub repository on your computer, in the `handbook` folder. You can rename this folder to any names you like - all the git-related information will be unchanged.
+   This means you will now have a local copy of all the contents in the GitHub repository on your computer in the `handbook` folder. You can rename this folder to any names you like - all the git-related information will be unchanged.
 
 4. Add the `upstream` remote
 
-   If you want to submit Pull Requests and share changes to the Handbook back to the community, you need to point git to the correct repos. You can do this by setting your [remote repositories](https://docs.github.com/get-started/getting-started-with-git/managing-remote-repositories).
+   If you want to submit pull requests and share changes to the Handbook back to the community, you need to point git to the correct repos. You can do this by setting your [remote repositories](https://docs.github.com/get-started/getting-started-with-git/managing-remote-repositories).
 
-   By convention, we will use the name `origin` to point to your fork of the repository, and we will call `upstream` the original Contributor Experience Handbook repo. To inform git, you can run the following command:
+   By convention, we will use the name `origin` to point to your fork of the repository and we will call `upstream` the original Contributor Experience Handbook repo. To inform git, you can run the following command:
 
    ```
     git remote add upstream https://github.com/contributor-experience/handbook.git
@@ -65,10 +65,8 @@ Never made an open source contribution before? Wondering how contributions work 
    git switch -c <branch-name>
    ```
 
-   It is good practice to create a new branch for each new fix/improvement your are working on. This ensures the history of the changes to the project is more organized. You can name your branch anything - this does not interfere with the commit history.
-
-
-
+   It is good practice to create a new branch for each new fix/improvement your are working on. This ensures that the history of the changes to the project is well organized. You can name your branch anything - this does not interfere with the commit history.
+  
 7. Once you finished making changes to the existing code, you need to add all these changes to the staging area and commit them to the branch you are working on
 
    ```
@@ -78,30 +76,30 @@ Never made an open source contribution before? Wondering how contributions work 
 
    where `<commit-message>` is a brief explanation of what you did.
 
-9. Push the changes to the remote repository using:
+8. Push the changes to the remote repository using:
 
    ```
    git push origin <branch-name>
    ```
 
-10. Submit a **pull request** to the upstream repository
+9. Submit a **pull request** to the upstream repository.
 
-11. Title the **pull request** with a short description of the changes made
+10. Title the **pull request** with a short description of the changes made.
 
-12. Wait for the pull request to be reviewed by the project team member
+11. Wait for the pull request to be reviewed by the project team member.
 
    Currently, the Contributor Experience project is led by a
    [team of three people](docs/about/team.qmd). While only these team members
-   have GitHub permissions to merge Pull Requests, we welcome Pull Request
+   have GitHub permissions to merge pull requests, we welcome pull request
    reviews by anyone - suggestions and comments are valuable contributions to
    our project.
 
-13. Make changes to the pull request if the reviewing team member recommends them
+12. Make changes to the pull request if the reviewing team member recommends them.
 
-14. Celebrate your success after your pull request is merged!
+13. Celebrate your success after your pull request is merged!
 
 ---
 
 Thanks for taking the time to contribute! ❤️
 
-Don't forget to leave a star 🌟
+Don't forget to leave a star. 🌟

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -1,91 +1,103 @@
-# Contribution Guideline
+# Contribution Guidelines
 
-<br>
+There are quite a few ways you could get involved with the Contributor Experience project. You can:
 
-## How do I make a contribution?
+- join one of our [community calls](docs/about/calendar.qmd);
+- join our [Zulip chat](https://contributor-experience.zulipchat.com/join/r3bbxavdymqbyjiu32mtqyqi/)
+- share your ideas by [filing issues](https://github.com/contributor-experience/handbook/issues/new), submitting [Pull Requests](https://docs.github.com/en/pull-requests) or commenting on existing discussions;
+- address issues filed by other contributors;
+- review submitted PRs.
 
-<br>
+## How do I make a contribution to the Handbook?
 
-Never made an open source contribution before? Wondering how contributions work in the in our project? Here's a quick rundown!
+Never made an open source contribution before? Wondering how contributions work in our project? Here's a quick rundown!
 
-<br>
+1. Find an issue that you are interested in addressing or a content page or feature that you would like to add.
 
-## **Here's a quick rundown on how to make a contribution to my project:**
+2. Fork the [Contributor Experience Handbook repository](https://github.com/contributor-experience/handbook) to your GitHub profile. This means that you will have a copy of the repository `<github-username>/handbook.`
 
----
-
-<br>
-
-1. Find an issue that you are interested in addressing or a feature that you would like to add.
-
-   <br>
-
-2. Fork the repository associated with the issue to your local GitHub organization. This means that you will have a copy of the repository `underyour-GitHub-username/repository-name.`
-
-   <br>
+   To fork the repository, you can use the `Fork` button on the GitHub web interface for this repo.
 
 3. Clone the repository to your local machine using:
 
    ```
-   git clone https://github.com/github-username/repository-name.git.
+   git clone https://github.com/<github-username>/handbook.git.
    ```
 
-4. Add the upstream remote:
+   This means you will now have a local copy of all the contents in the GitHub repository in your computer, under the `handbook` folder. You can rename this folder to any names you like - all the git-related information will be unchanged.
+
+4. Add the `upstream` remote
+
+   If you want to submit Pull Requests and share changes to the Handbook back to the community, you need to point git to the correct repos. You can do this by setting your [remote repositories](https://docs.github.com/get-started/getting-started-with-git/managing-remote-repositories).
+
+   By convention, we will use the name `origin` to point to your fork of the repository, and we will call `upstream` the original Contributor Experience Handbook repo. To inform git, you can run the following command:
 
    ```
     git remote add upstream https://github.com/contributor-experience/handbook.git
    ```
 
-5. Pull the latest changes from the main repository if you think your fork is behind:
+   Now, if you run
+
+   ```
+   git remote -v
+   ```
+
+   you should see something like:
+
+   ```
+   origin  git@github.com:<github-username>/handbook.git (fetch)
+   origin  git@github.com:<github-username>/handbook.git (push)
+   upstream        git@github.com:contributor-experience/handbook.git (fetch)
+   upstream        git@github.com:contributor-experience/handbook.git (push)
+   ```
+
+   This means you are all set!
+
+5. (Optional) Pull the latest changes from the main repository if you think your fork is behind:
 
    ```
    git pull upstream main
    ```
 
-6. Create a new branch and switch to it for your issue fix or feature using:
+6. Create a new branch and switch to it for your issue fix or content page using:
 
    ```
-   git switch -c branch-name-here
+   git switch -c <branch-name>
    ```
+
+   It is good practice to create a new branch for each new fix/improvement your are working on. This ensures the history of the changes to the project is more organized. You can name your branch anything - this does not interfere with the commit history.
 
 7. Make the appropriate changes for the issue you are trying to address or the feature that you want to add
 
-   <br>
+   This is when you write, fix existing content or otherwise do your magic ✨
 
-8. Add the changes to the staging are and commit them to the branch you are working on
+8. Add the changes to the staging area and commit them to the branch you are working on
 
-   <br>
+   ```
+   git add <files-to-be-changed>
+   git commit -m "<commit message>"
+   ```
+
+   where `<commit-message>` is a brief explanation of what you did.
 
 9. Push the changes to the remote repository using:
 
    ```
-   git push origin branch-name-here
+   git push origin <branch-name>
    ```
 
 10. Submit a **pull request** to the upstream repository
 
-   <br>
-
 11. Title the **pull request** with a short description of the changes made
-
-   <br>
 
 12. Wait for the pull request to be reviewed by a maintainer
 
-   <br>
-
 13. Make changes to the pull request if the reviewing maintainer recommends them
-
-   <br>
 
 14. Celebrate your success after your pull request is merged!
 
-## <br>
-
 ---
 
-### Thanks for taking the time to contribute! ❤️
+Thanks for taking the time to contribute! ❤️
 
-<br>
-
-### Don't forget to leave a star 🌟
+Don't forget to leave a star 🌟

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -87,6 +87,7 @@ website:
             - docs/about/acknowledging_contributors.qmd
             - docs/about/calendar.qmd
             - docs/about/comms_channels.qmd
+            - CONTRIBUTE.md
 
     - id: guide
       title: "Guide"


### PR DESCRIPTION
After merging #38 I realized this would show only on GitHub (which is good!) but not on the rendered website. So I added a few extra infos and fixed the formatting to fit the Quarto markdown style. 