### PR TITLE
Update calendar.qmd

### DIFF
--- a/docs/about/calendar.qmd
+++ b/docs/about/calendar.qmd
@@ -7,9 +7,9 @@ contributor experience. We are also planning on organizing more structured event
 to collaborate on documentation, host guest speakers, and highlight case studies 
 from around OSSverse.  
 
-Join us every Friday at 3pm UTC via [Zoom](https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09).
+Join us every Friday at 4:30 pm UTC via [Zoom](https://numfocus-org.zoom.us/j/81082067424?pwd=bVNqWXhqSXZEdTl6ZzFsa1lJZ08xZz09).
 Everyone is welcome to attend and contribute to a conversation.
 
 To keep track of our community events, subscribe to the Contributor Experience Project 
-calendar using the following [link](https://calendar.google.com/calendar/ical/c_f8e3d3d0f8033c525a9d03684964245d9018cf4c2630dff21d39a6356815f7db%40group.calendar.google.com/public/basic.ics). 
+calendar using the following [link](https://scientific-python.org/calendars/contributor-experience.ics). 
 (*Tip:* Look for the option to add a calendar subscription from URL in your calendar app of choice.)


### PR DESCRIPTION
1. Updating the time of the CEP community calls.
2. Linking to the calendar on the Scientific Python Project website (https://scientific-python.org/calendars/).