### PR TITLE
Update GHA to the latest major release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
+        uses: quarto-dev/quarto-actions/setup@v4
 
       - name: Render and Publish
-        uses: quarto-dev/quarto-actions/publish@v2
+        uses: quarto-dev/quarto-actions/publish@v4
         with:
           target: gh-pages
         env:


### PR DESCRIPTION
Updating the GH action `publish` to the latest major release to fix the deployment of the website.

P.S. Not sure if this can be fixed via a PR as I've never done it outside of my private projects.

