### PR TITLE
Add Dea María Léon and May Ireland to the Team page

### DIFF
--- a/docs/about/team.qmd
+++ b/docs/about/team.qmd
@@ -1,23 +1,12 @@
 ---
-title: "Team & History"
+title: "Team"
 sidebar: guide
 ---
 
-The founding and current maintainer team of this handbook in alphabetical 
-order is:
+The core team members of the Contributor Experience Project are (in alphabetical order):
 
-- Inessa Pawson 
-- Melissa Weber Mendonça 
+- Dea María Léon
+- Inessa Pawson
+- May Ireland
+- Melissa Mendonça 
 - Noa Tamir 
-
-Melissa initiated this work as the PI for the "Advancing an inclusive 
-culture in the scientific Python ecosystem" grant from the Chan-Zuckerberg 
-Initiative. You can read [the full grant application](https://figshare.
-com/articles/online_resource/Advancing_an_inclusive_culture_in_the_scientific_Python_ecosystem/16548063)
-for this Cycle 4 (2021-2023) Essential OSS Diversity Equity and Inclusion grant.
-
-Inessa joined the team soon after the grant started, and Noa join the team 
-in March 2022. Between the three of them, they are supporting the contributor 
-experience in the communities of NumPy, SciPy, Matplotlib, and pandas, as 
-well as developing this handbook of resources for based on their 
-cross-project experience and research. 


### PR DESCRIPTION
 Dea María Léon and May Ireland joined the CEP core team in July 2024. Updating the Team page to document the change.

Removing the text related to the history of the CZI grant. This fact is documented in https://contributor-experience.org/about.html